### PR TITLE
fix: vpn bugs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,7 @@ android {
 			Constants.SENTRY_DSN,
 			"\"${(System.getenv(Constants.SENTRY_DSN) ?: getLocalProperty("sentry.dsn")) ?: ""}\"",
 		)
+		buildConfigField("Boolean", "IS_SANDBOX", "false")
 		buildConfigField("Boolean", Constants.OPT_IN_REPORTING, "false")
 		proguardFile("fdroid-rules.pro")
 	}
@@ -131,6 +132,7 @@ android {
 			proguardFile("proguard-rules.pro")
 		}
 		create(Constants.SANDBOX) {
+			buildConfigField("Boolean", "IS_SANDBOX", "true")
 			dimension = Constants.TYPE
 		}
 	}

--- a/app/src/main/java/net/nymtech/nymvpn/NymVpn.kt
+++ b/app/src/main/java/net/nymtech/nymvpn/NymVpn.kt
@@ -12,6 +12,7 @@ import net.nymtech.nymvpn.service.tile.VpnQuickTile
 import net.nymtech.nymvpn.util.log.DebugTree
 import net.nymtech.nymvpn.util.log.ReleaseTree
 import net.nymtech.nymvpn.util.navigationBarHeight
+import net.nymtech.vpn.model.Environment
 import timber.log.Timber
 
 @HiltAndroidApp
@@ -30,6 +31,8 @@ class NymVpn : Application() {
 	companion object {
 		lateinit var instance: NymVpn
 			private set
+
+		val environment = if (BuildConfig.IS_SANDBOX) Environment.SANDBOX else Environment.MAINNET
 
 		private const val BASELINE_HEIGHT = 2201
 		private const val BASELINE_WIDTH = 1080

--- a/app/src/main/java/net/nymtech/nymvpn/module/ServiceModule.kt
+++ b/app/src/main/java/net/nymtech/nymvpn/module/ServiceModule.kt
@@ -6,8 +6,11 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import net.nymtech.nymvpn.NymVpn
 import net.nymtech.nymvpn.service.gateway.GatewayApiService
 import net.nymtech.nymvpn.util.Constants
+import net.nymtech.vpn.NymVpnClient
+import net.nymtech.vpn.VpnClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
@@ -36,5 +39,11 @@ class ServiceModule {
 	@Provides
 	fun provideGatewayService(retrofit: Retrofit): GatewayApiService {
 		return retrofit.create(GatewayApiService::class.java)
+	}
+
+	@Singleton
+	@Provides
+	fun provideVpnClient(): VpnClient {
+		return NymVpnClient.init(environment = NymVpn.environment)
 	}
 }

--- a/app/src/main/java/net/nymtech/nymvpn/module/ViewModelModule.kt
+++ b/app/src/main/java/net/nymtech/nymvpn/module/ViewModelModule.kt
@@ -1,0 +1,19 @@
+package net.nymtech.nymvpn.module
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+import net.nymtech.vpn.NymApi
+import net.nymtech.nymvpn.NymVpn
+
+@Module
+@InstallIn(ViewModelComponent::class)
+internal object ViewModelModule {
+	@Provides
+	@ViewModelScoped
+	fun provideNymApi(): NymApi {
+		return NymApi(NymVpn.environment)
+	}
+}

--- a/app/src/main/java/net/nymtech/nymvpn/receiver/BootReceiver.kt
+++ b/app/src/main/java/net/nymtech/nymvpn/receiver/BootReceiver.kt
@@ -8,7 +8,7 @@ import net.nymtech.nymvpn.NymVpn
 import net.nymtech.nymvpn.data.GatewayRepository
 import net.nymtech.nymvpn.data.SettingsRepository
 import net.nymtech.nymvpn.util.goAsync
-import net.nymtech.vpn.NymVpnClient
+import net.nymtech.vpn.VpnClient
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -19,6 +19,9 @@ class BootReceiver : BroadcastReceiver() {
 	@Inject
 	lateinit var settingsRepository: SettingsRepository
 
+	@Inject
+	lateinit var vpnClient: VpnClient
+
 	override fun onReceive(context: Context?, intent: Intent?) = goAsync {
 		if (Intent.ACTION_BOOT_COMPLETED != intent?.action) return@goAsync
 		if (settingsRepository.isAutoStartEnabled()) {
@@ -28,8 +31,11 @@ class BootReceiver : BroadcastReceiver() {
 			context?.let { context ->
 				val entry = entryCountry.toEntryPoint()
 				val exit = exitCountry.toExitPoint()
-				NymVpnClient.configure(entry, exit, mode)
-				NymVpnClient.start(context)
+				vpnClient.apply {
+					this.mode = mode
+					this.exitPoint = exit
+					this.entryPoint = entry
+				}.start(context, true)
 				NymVpn.requestTileServiceStateUpdate(context)
 			}
 		}

--- a/app/src/main/java/net/nymtech/nymvpn/service/AlwaysOnVpnService.kt
+++ b/app/src/main/java/net/nymtech/nymvpn/service/AlwaysOnVpnService.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.launch
 import net.nymtech.nymvpn.NymVpn
 import net.nymtech.nymvpn.data.GatewayRepository
 import net.nymtech.nymvpn.data.SettingsRepository
-import net.nymtech.vpn.NymVpnClient
+import net.nymtech.vpn.VpnClient
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -20,6 +20,9 @@ class AlwaysOnVpnService : LifecycleService() {
 
 	@Inject
 	lateinit var settingsRepository: SettingsRepository
+
+	@Inject
+	lateinit var vpnClient: VpnClient
 
 	override fun onBind(intent: Intent): IBinder? {
 		super.onBind(intent)
@@ -36,8 +39,12 @@ class AlwaysOnVpnService : LifecycleService() {
 				val mode = settingsRepository.getVpnMode()
 				val entry = entryCountry.toEntryPoint()
 				val exit = exitCountry.toExitPoint()
-				NymVpnClient.configure(entry, exit, mode)
-				NymVpnClient.start(this@AlwaysOnVpnService)
+				vpnClient.apply {
+					this.mode = mode
+					this.entryPoint = entry
+					this.exitPoint = exit
+				}
+				vpnClient.start(this@AlwaysOnVpnService, true)
 				NymVpn.requestTileServiceStateUpdate(this@AlwaysOnVpnService)
 			}
 			START_STICKY

--- a/app/src/main/java/net/nymtech/nymvpn/ui/AppUiState.kt
+++ b/app/src/main/java/net/nymtech/nymvpn/ui/AppUiState.kt
@@ -1,6 +1,7 @@
 package net.nymtech.nymvpn.ui
 
 import net.nymtech.nymvpn.ui.theme.Theme
+import net.nymtech.vpn.model.VpnState
 
 data class AppUiState(
 	val loading: Boolean = true,
@@ -8,4 +9,5 @@ data class AppUiState(
 	val loggedIn: Boolean = false,
 	val snackbarMessage: String = "",
 	val snackbarMessageConsumed: Boolean = true,
+	val vpnState: VpnState = VpnState.Down,
 )

--- a/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/net/nymtech/nymvpn/ui/screens/main/MainScreen.kt
@@ -154,14 +154,14 @@ fun MainScreen(navController: NavController, appUiState: AppUiState, viewModel: 
 					ListOptionSelectionButton(
 						label = stringResource(R.string.first_hop),
 						value = firstHopName,
-						onClick = { navController.navigate(NavItem.Hop.Entry.route) },
+						onClick = { if (uiState.connectionState is ConnectionState.Disconnected) navController.navigate(NavItem.Hop.Entry.route) },
 						leadingIcon = firstHopIcon,
 					)
 				}
 				ListOptionSelectionButton(
 					label = stringResource(R.string.last_hop),
 					value = lastHopName,
-					onClick = { navController.navigate(NavItem.Hop.Exit.route) },
+					onClick = { if (uiState.connectionState is ConnectionState.Disconnected) navController.navigate(NavItem.Hop.Exit.route) },
 					leadingIcon = lastHopIcon,
 				)
 			}

--- a/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/SettingsScreen.kt
@@ -35,6 +35,7 @@ import net.nymtech.nymvpn.ui.common.buttons.surface.SelectionItem
 import net.nymtech.nymvpn.ui.common.buttons.surface.SurfaceSelectionGroupButton
 import net.nymtech.nymvpn.util.scaledHeight
 import net.nymtech.nymvpn.util.scaledWidth
+import net.nymtech.vpn.model.VpnState
 
 @Composable
 fun SettingsScreen(
@@ -117,6 +118,7 @@ fun SettingsScreen(
 							Modifier
 								.height(32.dp.scaledHeight())
 								.width(52.dp.scaledWidth()),
+							enabled = (appUiState.vpnState is VpnState.Down),
 						)
 					},
 					stringResource(R.string.entry_location),

--- a/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/login/LoginScreen.kt
+++ b/app/src/main/java/net/nymtech/nymvpn/ui/screens/settings/login/LoginScreen.kt
@@ -147,7 +147,10 @@ fun LoginScreen(navController: NavController, appViewModel: AppViewModel, viewMo
 					viewModel.onLogin(recoveryPhrase).let {
 						when (it) {
 							is Result.Success -> {
-								navController.navigate(NavItem.Main.route)
+								navController.navigate(NavItem.Main.route) {
+									// clear backstack after login
+									popUpTo(0)
+								}
 								appViewModel.showSnackbarMessage(
 									context.getString(R.string.credential_successful),
 								)

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -1,8 +1,8 @@
 import org.gradle.api.JavaVersion
 
 object Constants {
-    const val VERSION_NAME = "v0.1.2-alpha"
-    const val VERSION_CODE = 12
+    const val VERSION_NAME = "v0.1.2"
+    const val VERSION_CODE = 13
     const val TARGET_SDK = 34
     const val COMPILE_SDK = 34
     const val MIN_SDK = 24
@@ -28,12 +28,6 @@ object Constants {
     const val GENERAL = "general"
     const val SANDBOX = "sandbox"
     const val BUILD_LIB_TASK = "buildDeps"
-
-    const val SANDBOX_API_URL = "https://sandbox-nym-api1.nymtech.net/api"
-    const val SANDBOX_EXPLORER_URL = "https://sandbox-explorer.nymtech.net/api"
-
-    const val MAINNET_API_URL = "https://validator.nymtech.net/api/"
-    const val MAINNET_EXPLORER_URL = "https://explorer.nymtech.net/api/"
 
     //licensee
     val allowedLicenses = listOf("MIT", "Apache-2.0", "BSD-3-Clause")

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -42,6 +42,8 @@ complexity:
     active: false
   LongMethod:
     active: false
+  ComplexCondition:
+      threshold: 5
   CyclomaticComplexMethod:
     ignoreAnnotated:
         - 'Composable'

--- a/fastlane/metadata/android/en-US/changelogs/13.txt
+++ b/fastlane/metadata/android/en-US/changelogs/13.txt
@@ -1,0 +1,5 @@
+What's new:
+- Fix file descriptor bug
+- Fix v5 nym api bug
+- Fix ipv6/ipv4 vpn stops
+- Other bug fixes

--- a/nym_vpn_client/build.gradle.kts
+++ b/nym_vpn_client/build.gradle.kts
@@ -19,9 +19,6 @@ android {
 		minSdk = Constants.MIN_SDK
 		testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 		consumerProguardFiles("consumer-rules.pro")
-		buildConfigField("String", "API_URL", "\"${Constants.MAINNET_API_URL}\"")
-		buildConfigField("String", "EXPLORER_URL", "\"${Constants.MAINNET_EXPLORER_URL}\"")
-		buildConfigField("Boolean", "IS_SANDBOX", "false")
 	}
 
 	buildTypes {
@@ -46,9 +43,6 @@ android {
 			}
 			create(Constants.SANDBOX) {
 				dimension = Constants.TYPE
-				buildConfigField("String", "API_URL", "\"${Constants.SANDBOX_API_URL}\"")
-				buildConfigField("String", "EXPLORER_URL", "\"${Constants.SANDBOX_EXPLORER_URL}\"")
-				buildConfigField("Boolean", "IS_SANDBOX", "true")
 			}
 		}
 	}

--- a/nym_vpn_client/src/main/java/net/nymtech/vpn/NotificationManager.kt
+++ b/nym_vpn_client/src/main/java/net/nymtech/vpn/NotificationManager.kt
@@ -10,9 +10,9 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import net.nymtech.vpn_client.R
 
-internal object NotificationService {
+internal object NotificationManager {
 
-	const val VPN_CHANNEL_ID = "vpnChannel"
+	private const val VPN_CHANNEL_ID = "vpnChannel"
 	fun createNotificationChannel(context: Context) {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 			// Create the NotificationChannel.

--- a/nym_vpn_client/src/main/java/net/nymtech/vpn/NymApi.kt
+++ b/nym_vpn_client/src/main/java/net/nymtech/vpn/NymApi.kt
@@ -1,0 +1,30 @@
+package net.nymtech.vpn
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.nymtech.vpn.model.Country
+import net.nymtech.vpn.model.Environment
+import nym_vpn_lib.getGatewayCountries
+
+class NymApi(private val environment: Environment) {
+	suspend fun gateways(exitOnly: Boolean): Set<Country> {
+		return withContext(Dispatchers.IO) {
+			getGatewayCountries(environment.apiUrl, environment.explorerUrl, exitOnly).map {
+				Country(isoCode = it.twoLetterIsoCountryCode)
+			}.toSet()
+		}
+	}
+
+	suspend fun getLowLatencyEntryCountry(): Country {
+		return withContext(Dispatchers.IO) {
+			Country(
+				isoCode =
+				nym_vpn_lib.getLowLatencyEntryCountry(
+					environment.apiUrl,
+					environment.explorerUrl,
+				).twoLetterIsoCountryCode,
+				isLowLatency = true,
+			)
+		}
+	}
+}

--- a/nym_vpn_client/src/main/java/net/nymtech/vpn/VpnClient.kt
+++ b/nym_vpn_client/src/main/java/net/nymtech/vpn/VpnClient.kt
@@ -4,27 +4,22 @@ import android.content.Context
 import android.content.Intent
 import kotlinx.coroutines.flow.Flow
 import net.nymtech.vpn.model.ClientState
-import net.nymtech.vpn.model.Country
 import net.nymtech.vpn.model.VpnMode
 import nym_vpn_lib.EntryPoint
 import nym_vpn_lib.ExitPoint
 
 interface VpnClient {
-	fun configure(entryPoint: EntryPoint, exitPoint: ExitPoint, mode: VpnMode = VpnMode.TWO_HOP_MIXNET)
+
+	var entryPoint: EntryPoint
+	var exitPoint: ExitPoint
+	var mode: VpnMode
+	fun start(context: Context, foreground: Boolean = false)
+
+	fun stop(context: Context, foreground: Boolean = false)
 
 	fun prepare(context: Context): Intent?
-
-	fun start(context: Context)
-
-	fun startForeground(context: Context)
-
-	fun disconnect(context: Context)
 
 	val stateFlow: Flow<ClientState>
 
 	fun getState(): ClientState
-
-	suspend fun gateways(exitOnly: Boolean = false): Set<Country>
-
-	suspend fun getLowLatencyEntryCountryCode(): Country
 }

--- a/nym_vpn_client/src/main/java/net/nymtech/vpn/model/Environment.kt
+++ b/nym_vpn_client/src/main/java/net/nymtech/vpn/model/Environment.kt
@@ -1,0 +1,20 @@
+package net.nymtech.vpn.model
+
+import java.net.URL
+enum class Environment {
+	MAINNET {
+		override val apiUrl: URL
+			get() = URL("https://validator.nymtech.net/api/")
+		override val explorerUrl: URL
+			get() = URL("https://explorer.nymtech.net/api/")
+	},
+	SANDBOX {
+		override val apiUrl: URL
+			get() = URL("https://sandbox-nym-api1.nymtech.net/api")
+		override val explorerUrl: URL
+			get() = URL("https://sandbox-explorer.nymtech.net/api")
+	}, ;
+
+	abstract val apiUrl: URL
+	abstract val explorerUrl: URL
+}


### PR DESCRIPTION
Fixes a bug where file descriptor was not being closed properly causing a crash on reconnection.

Fixes a bug where the VPN would shutdown if ipv6 or ipv4 traffic is not being routed correctly due to a misconfigured gateway.

Fixes a bug where vpn state could become out of sync with the lib.

Fixes a bug where user could change entry/exit points while vpn was not disconnected.

Fixes a bug where users could navigate back to the login screen even after already being logged in.

Refactor of nymvpn android lib to improve usability and state synchronization.